### PR TITLE
Enable requiring modules that rely on strict mode.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,7 @@ var user = SandboxedModule.require('./user', {
   requires: {'mysql': {fake: 'mysql module'}},
   globals: {myGlobal: 'variable'},
   locals: {myLocal: 'other variable'},
+  strictMode : true
 });
 ```
 
@@ -44,6 +45,8 @@ following:
   of the sandboxed module.
 * `globals:` An object of global variables to inject into the sandboxed module.
 * `locals:` An object of local variables to inject into the sandboxed module.
+* `strictMode:` A boolean flag that will inclue `"use strict";` when wrapping
+  the sandboxed module.
 
 ### SandboxedModule.require(moduleId, [options])
 

--- a/lib/sandboxed_module.js
+++ b/lib/sandboxed_module.js
@@ -152,6 +152,7 @@ SandboxedModule.prototype._getCompileInfo = function() {
   }
 
   var source =
+    ( this._options.strictMode ? '"use strict";\n' : '' ) +
     '(function(' + localVariables.join(', ')  + ') { ' +
     'global = GLOBAL = root = (function() { return this; })();' +
     sourceToWrap +


### PR DESCRIPTION
This is my solution to a problem where I wanted to sandbox a module that used ES6 Harmony features such as `let`.

I can now enable v8 "extended mode" by running tests using `--harmony` flag and requiring sandboxed modules with `"use strict";` by providing `strictMode : true` options when requiring.
