### PR TITLE
Use both the '$$cov_*' and istanbul's default `__coverage__` var to see if istanbul is running

### DIFF
--- a/lib/sandboxed_module.js
+++ b/lib/sandboxed_module.js
@@ -237,7 +237,7 @@ var builtInSourceTransformers = {
   istanbul: function(source) {
     var coverageVariable, istanbulCoverageMayBeRunning = false;
     Object.keys(global).forEach(function(name) {
-      if(name.indexOf("$$cov_") == 0 && global[name]) {
+      if((name.indexOf("$$cov_") === 0 || name === '__coverage__') && global[name]) {
         istanbulCoverageMayBeRunning = true;
         coverageVariable = name;
       }

--- a/test/integration/test-istanbul.js
+++ b/test/integration/test-istanbul.js
@@ -2,10 +2,15 @@ var assert = require('assert');
 var SandboxedModule = require('../..');
 SandboxedModule.registerBuiltInSourceTransformer('istanbul');
 
-global['$$cov_1234'] = {};
-var baz = SandboxedModule.load('../fixture/baz').exports,
-    instrumentedFunction = /^function \(\){__cov_.*\.f\['1'\]\+\+;__cov_.*\.s\['2'\]\+\+;return 1\+3;}$/;
+function testIt(coverageVariable) {
+    global[coverageVariable] = {};
+    var baz = SandboxedModule.load('../fixture/baz').exports,
+        instrumentedFunction = /^function \(\){__cov_.*\.f\['1'\]\+\+;__cov_.*\.s\['2'\]\+\+;return 1\+3;}$/;
 
-assert.strictEqual(baz.biz.toString().match(instrumentedFunction).length, 1);
+    assert.strictEqual(baz.biz.toString().match(instrumentedFunction).length, 1);
 
-delete global['$$cov_1234'];
+    delete global[coverageVariable];
+}
+
+testIt('$$cov_1234');
+testIt('__coverage__');


### PR DESCRIPTION
Currently it's only looking for the $$cov_ global variable to know if istanbul is running.  If you use istanbul programmatically, it doesn't instantiate $$cov_ but uses the default `__coverage__` var.  (see https://github.com/gotwarlost/istanbul/blob/master/lib/instrumenter.js#L340)  A great example of using istanbul programatically is https://www.npmjs.org/package/gulp-istanbul.
