### PR TITLE
Fix compling souces ending with an end-of-line comment

### DIFF
--- a/lib/sandboxed_module.js
+++ b/lib/sandboxed_module.js
@@ -257,7 +257,7 @@ SandboxedModule.prototype._getCompileInfo = function() {
   var source =
     '(function(global,' + localVariables.join(', ')  + ') { ' +
     sourceToWrap +
-    '});';
+    '\n});';
 
   return {source: source, parameters: localValues};
 };


### PR DESCRIPTION
Sources ending with an end-of-line comment (not followed by a newline character) aren't wrapped properly. The second part of the wrapper is treated as part of the comment in such a case. Adding a newline character in fixes this issue.
