### PR TITLE
Copy sandbox options when recursing

### DIFF
--- a/lib/sandboxed_module.js
+++ b/lib/sandboxed_module.js
@@ -159,13 +159,14 @@ SandboxedModule.prototype._createRecursiveRequireProxy = function() {
   }
   cache[this.filename] = this.exports;
   var globals = this.globals;
+  var options = this._options;
 
   function createInnerSandboxedModule(requestedFilename){
       // load nested dependency in sandboxed module
       var sandboxedModule = new SandboxedModule();
       sandboxedModule._getGlobals = function(){return globals};
       var trace = stackTrace.get(createInnerSandboxedModule);
-      sandboxedModule._init(requestedFilename,trace);
+      sandboxedModule._init(requestedFilename,trace,options);
       var proxyRequire = bindRequire(RecursiveRequireProxy,sandboxedModule);
       sandboxedModule.locals.require = proxyRequire;
       sandboxedModule.module.require = proxyRequire


### PR DESCRIPTION
See https://github.com/felixge/node-sandboxed-module/issues/41.

Given:

``` js
var SandboxedModule = require('sandboxed-module');

SandboxedModule.require('./foo', { sourceTransformers: {
    test: function (source) {
        console.log('test source transformer:', this.filename);
        return source;
    }
}});
```

I would expect that any calls to require inside of the sandboxed module would carry the same options (e.g. `sourceTransformers`) as the initial sandboxed module.
