### PR TITLE
Add a recursive reference to the global object

### DIFF
--- a/lib/sandboxed_module.js
+++ b/lib/sandboxed_module.js
@@ -106,6 +106,8 @@ SandboxedModule.prototype._getLocals = function() {
 SandboxedModule.prototype._getGlobals = function() {
   var globals = getStartingGlobals();
 
+  globals.global = globals;
+
   for (var globalKey in global) {
     globals[globalKey] = global[globalKey];
   }


### PR DESCRIPTION
I would like to sandbox a module without mocking rxjs out.
The problem is that it looks on the global object whether it has a recursive property pointing to itself: https://github.com/ReactiveX/rxjs/blob/5.0.0-beta.3/src/util/root.ts#L28
