### PR TITLE
Allow filtering of files transformed by built-in source transformers.

### DIFF
--- a/lib/sandboxed_module.js
+++ b/lib/sandboxed_module.js
@@ -8,6 +8,7 @@ var builtinModules = require('./builtin_modules.json');
 var parent = module.parent;
 var globalOptions = {};
 var registeredBuiltInSourceTransformers = ['coffee'];
+var builtInSourceTransformersConfig = {};
 
 module.exports = SandboxedModule;
 function SandboxedModule() {
@@ -27,7 +28,7 @@ SandboxedModule.load = function(moduleId, options, trace) {
 
   var sandboxedModule = new SandboxedModule();
   sandboxedModule._init(moduleId, trace, options);
-  sandboxedModule._compile()
+  sandboxedModule._compile();
   return sandboxedModule;
 };
 
@@ -42,10 +43,11 @@ SandboxedModule.configure = function(options) {
   });
 };
 
-SandboxedModule.registerBuiltInSourceTransformer = function(name) {
+SandboxedModule.registerBuiltInSourceTransformer = function(name, config) {
   if(registeredBuiltInSourceTransformers.indexOf(name) === -1) {
-    registeredBuiltInSourceTransformers.push(name)
+    registeredBuiltInSourceTransformers.push(name);
   }
+  builtInSourceTransformersConfig[name] = config;
 };
 
 
@@ -308,24 +310,33 @@ function getStartingSourceTransformers() {
 var builtInSourceTransformers = {
   coffee: function(source) {
     if (this.filename.search(/\.coffee$/) !== -1){
-      return require('coffee-script').compile(source);
+      return require('coffee-script').compile(source, builtInSourceTransformersConfig.coffee);
     } else {
       return source;
     }
   },
   istanbul: function(source) {
-    var coverageVariable, istanbulCoverageMayBeRunning = false;
-    Object.keys(global).forEach(function(name) {
-      if((name.indexOf("$$cov_") === 0 || name === '__coverage__') && global[name]) {
-        istanbulCoverageMayBeRunning = true;
-        coverageVariable = name;
-      }
-    });
+    var config = {};
+    if(builtInSourceTransformersConfig.istanbul) {
+      Object.keys(builtInSourceTransformersConfig.istanbul).forEach(function(option) {
+        config[option] = builtInSourceTransformersConfig.istanbul[option];
+      });
+    }
+
+    var istanbulCoverageMayBeRunning = config.coverageVariable && global[config.coverageVariable];
+    if(!istanbulCoverageMayBeRunning) {
+      Object.keys(global).forEach(function(name) {
+        if((name.indexOf("$$cov_") === 0 || name === '__coverage__') && global[name]) {
+          istanbulCoverageMayBeRunning = true;
+          config.coverageVariable = name;
+        }
+      });
+    }
 
     if(istanbulCoverageMayBeRunning) {
       try {
         var istanbul = require('istanbul'),
-            instrumenter = new istanbul.Instrumenter({coverageVariable: coverageVariable}),
+            instrumenter = new istanbul.Instrumenter(config),
             instrumentMethod = instrumenter.instrumentSync.bind(instrumenter);
         source = instrumentMethod(source, this.filename);
       } catch(e) {}

--- a/lib/sandboxed_module.js
+++ b/lib/sandboxed_module.js
@@ -9,6 +9,7 @@ var parent = module.parent;
 var globalOptions = {};
 var registeredBuiltInSourceTransformers = ['coffee'];
 var builtInSourceTransformersConfig = {};
+var builtInSourceTransformersFilters = {};
 
 module.exports = SandboxedModule;
 function SandboxedModule() {
@@ -43,11 +44,12 @@ SandboxedModule.configure = function(options) {
   });
 };
 
-SandboxedModule.registerBuiltInSourceTransformer = function(name, config) {
+SandboxedModule.registerBuiltInSourceTransformer = function(name, config, filter) {
   if(registeredBuiltInSourceTransformers.indexOf(name) === -1) {
     registeredBuiltInSourceTransformers.push(name);
   }
   builtInSourceTransformersConfig[name] = config;
+  builtInSourceTransformersFilters[name] = filter;
 };
 
 
@@ -309,13 +311,19 @@ function getStartingSourceTransformers() {
 
 var builtInSourceTransformers = {
   coffee: function(source) {
-    if (this.filename.search(/\.coffee$/) !== -1){
+    var fileFilter = builtInSourceTransformersFilters.coffee;
+    if (this.filename.search(/\.coffee$/) !== -1 && (!fileFilter || fileFilter.test(this.filename))){
       return require('coffee-script').compile(source, builtInSourceTransformersConfig.coffee);
     } else {
       return source;
     }
   },
   istanbul: function(source) {
+    var fileFilter = builtInSourceTransformersFilters.istanbul;
+    if(fileFilter && !fileFilter.test(this.filename)) {
+      return source;
+    }
+
     var config = {};
     if(builtInSourceTransformersConfig.istanbul) {
       Object.keys(builtInSourceTransformersConfig.istanbul).forEach(function(option) {

--- a/test/fixture/filteredBaz.js
+++ b/test/fixture/filteredBaz.js
@@ -1,0 +1,8 @@
+module.exports = {
+  biz: function(){
+    return 1 + 3;
+  },
+  bang: function() {
+    return require('./foo') + someLocal + someGlobal + 3;
+  }
+};

--- a/test/fixture/filteredCoffee.coffee
+++ b/test/fixture/filteredCoffee.coffee
@@ -1,0 +1,5 @@
+class coffeeClass
+  simpleData: ->
+    1 + 1
+
+module.exports = coffeeClass

--- a/test/integration/test-coffee.js
+++ b/test/integration/test-coffee.js
@@ -7,7 +7,15 @@ try {
   hasCoffee = true;
 } catch (e) {}
 
-if (hasCoffee) {
-  var CoffeeClass = SandboxedModule.load('../fixture/coffeeClass').exports;
+function testCoffee(file) {
+  var CoffeeClass = SandboxedModule.load(file).exports;
   assert.strictEqual(new CoffeeClass().simpleData(), 2);
+}
+
+if (hasCoffee) {
+  testCoffee('../fixture/coffeeClass');
+
+  SandboxedModule.registerBuiltInSourceTransformer('coffee', null, /.*filtered.*$/);
+  assert.throws(testCoffee.bind(null, '../fixture/coffeeClass'));
+  testCoffee('../fixture/filteredCoffee');
 }

--- a/test/integration/test-istanbul.js
+++ b/test/integration/test-istanbul.js
@@ -2,15 +2,23 @@ var assert = require('assert');
 var SandboxedModule = require('../..');
 SandboxedModule.registerBuiltInSourceTransformer('istanbul');
 
-function testIt(coverageVariable) {
-    global[coverageVariable] = {};
-    var baz = SandboxedModule.load('../fixture/baz').exports,
-        instrumentedFunction = /^function \(\){__cov_.*\.f\['1'\]\+\+;__cov_.*\.s\['2'\]\+\+;return 1\+3;}$/;
+var rawFunction = /^\s*function \(\){\s*return 1 \+ 3;\s*}\s*$/,
+    instrumentedFunction = /^function \(\){__cov_.*\.f\['1'\]\+\+;__cov_.*\.s\['2'\]\+\+;return 1\+3;}$/;
 
-    assert.strictEqual(baz.biz.toString().match(instrumentedFunction).length, 1);
+function testIt(file, coverageVariable, functionMatch) {
+    global[coverageVariable] = {};
+    var baz = SandboxedModule.load(file).exports;
+
+    assert.strictEqual(baz.biz.toString().match(functionMatch).length, 1);
 
     delete global[coverageVariable];
 }
 
-testIt('$$cov_1234');
-testIt('__coverage__');
+testIt('../fixture/baz', '$$cov_1234', instrumentedFunction);
+testIt('../fixture/baz', '__coverage__', instrumentedFunction);
+
+SandboxedModule.registerBuiltInSourceTransformer('istanbul', null, /.*filtered.*$/);
+testIt('../fixture/baz', '$$cov_1234', rawFunction);
+testIt('../fixture/baz', '__coverage__', rawFunction);
+testIt('../fixture/filteredBaz', '$$cov_1234', instrumentedFunction);
+testIt('../fixture/filteredBaz', '__coverage__', instrumentedFunction);


### PR DESCRIPTION
Hi,

This is related to and based on https://github.com/felixge/node-sandboxed-module/pull/58.

This allows you to specify a regex when registering built-in source transformers, which will cause transformers only to be ran of files than match the regex.

This was useful to us, to prevent istanbul coverage being generated for files we didn't want (e.g. ```node_modules```).

This PR does have tests - hopefully they are sufficient - but since the branch is based on https://github.com/felixge/node-sandboxed-module/pull/58 then you may not want to merge it until that also has tests.

Cheers!