### PR TITLE
Added the cache option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -52,6 +52,7 @@ using the same options that were used for the original sandboxed module.
 * `sourceTransformersSingleOnly:` If false, the source transformers will not be run against
 modules required by the sandboxed module. By default it will take the same value as
 `singleOnly`.
+* `cache:` An object which is used by the recursive require logic to cache loaded modules. Useful if you want to share the cache between multiple SandboxedModule instances. Only used when `singleOnly` is false.
 
 ### SandboxedModule.require(moduleId, [options])
 

--- a/lib/sandboxed_module.js
+++ b/lib/sandboxed_module.js
@@ -154,7 +154,7 @@ function bindRequire(proxy, sandboxedModule) {
   return req;
 }
 SandboxedModule.prototype._createRecursiveRequireProxy = function() {
-  var cache = Object.create(null);
+  var cache = this._options.cache || globalOptions.cache || Object.create(null);
   var required = this._getRequires();
   for (var key in required) {
     var injectedFilename = requireLike(this.filename).resolve(key);


### PR DESCRIPTION
Hi,

Thanks for creating this library, very useful. Anyway I'm porting some unit tests to use it and found that I needed to make this small change. I needed to be able to share the module cache between SandBoxedModule instances. Any chance you could merge?

Thanks, Dave.

(CC @palant)