### PR TITLE
Fix sandboxed-module not working when using npx

### DIFF
--- a/lib/sandboxed_module.js
+++ b/lib/sandboxed_module.js
@@ -79,6 +79,10 @@ SandboxedModule.prototype._init = function(moduleId, trace, options) {
 
 SandboxedModule.prototype._resolveFilename = function(trace) {
   var originPath = trace[0].getFileName();
+  var fileScheme = 'file://';
+  if (originPath.startsWith(fileScheme)) {
+    originPath = originPath.substr(fileScheme.length);
+  }
   this.filename = requireLike(originPath).resolve(this.id);
 };
 

--- a/lib/sandboxed_module.js
+++ b/lib/sandboxed_module.js
@@ -3,6 +3,7 @@ var stackTrace = require('stack-trace');
 var Module = require('module');
 var fs = require('fs');
 var vm = require('vm');
+var url = require('url');
 var path = require('path');
 var builtinModules = require('./builtin_modules.json');
 var parent = module.parent;
@@ -81,7 +82,11 @@ SandboxedModule.prototype._resolveFilename = function(trace) {
   var originPath = trace[0].getFileName();
   var fileScheme = 'file://';
   if (originPath.substring(0, fileScheme.length) === fileScheme) {
-    originPath = originPath.substring(fileScheme.length);
+    if (url.fileURLToPath) {
+      originPath = url.fileURLToPath(originPath)
+    } else {
+      originPath = originPath.substring(fileScheme.length);
+    }
   }
   this.filename = requireLike(originPath).resolve(this.id);
 };

--- a/lib/sandboxed_module.js
+++ b/lib/sandboxed_module.js
@@ -83,7 +83,7 @@ SandboxedModule.prototype._resolveFilename = function(trace) {
   var fileScheme = 'file://';
   if (originPath.substring(0, fileScheme.length) === fileScheme) {
     if (url.fileURLToPath) {
-      originPath = url.fileURLToPath(originPath)
+      originPath = url.fileURLToPath(originPath);
     } else {
       originPath = originPath.substring(fileScheme.length);
     }

--- a/lib/sandboxed_module.js
+++ b/lib/sandboxed_module.js
@@ -80,7 +80,7 @@ SandboxedModule.prototype._init = function(moduleId, trace, options) {
 SandboxedModule.prototype._resolveFilename = function(trace) {
   var originPath = trace[0].getFileName();
   var fileScheme = 'file://';
-  if (originPath.startsWith(fileScheme)) {
+  if (originPath.substr(0, fileScheme.length) === fileScheme) {
     originPath = originPath.substr(fileScheme.length);
   }
   this.filename = requireLike(originPath).resolve(this.id);

--- a/lib/sandboxed_module.js
+++ b/lib/sandboxed_module.js
@@ -80,8 +80,8 @@ SandboxedModule.prototype._init = function(moduleId, trace, options) {
 SandboxedModule.prototype._resolveFilename = function(trace) {
   var originPath = trace[0].getFileName();
   var fileScheme = 'file://';
-  if (originPath.substr(0, fileScheme.length) === fileScheme) {
-    originPath = originPath.substr(fileScheme.length);
+  if (originPath.substring(0, fileScheme.length) === fileScheme) {
+    originPath = originPath.substring(fileScheme.length);
   }
   this.filename = requireLike(originPath).resolve(this.id);
 };


### PR DESCRIPTION
This PR fixes originPath being a URL instead of a path.

The `requireLike(…).resolve` function accepts a path, but `CallSite.getFileName(…)` returns a URI with `file://` scheme. This commit fixes the issue by removing the prefix if origin path starts with file scheme.

Since module path resolution looks for node_modules in all directories of $PWD, the issue does not arise during development. However, scripts started by `npx` that depend on sandboxed-module package would break with MODULE_NOT_FOUND error.